### PR TITLE
Move passwordAdmin to game section of produced server.json

### DIFF
--- a/ArmaReforgerServerTool/ReforgerServerApp.csproj
+++ b/ArmaReforgerServerTool/ReforgerServerApp.csproj
@@ -8,8 +8,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
     <Company>soda3x</Company>
-    <AssemblyVersion>0.6.0</AssemblyVersion>
-    <FileVersion>0.6.0</FileVersion>
+    <AssemblyVersion>0.6.1</AssemblyVersion>
+    <FileVersion>0.6.1</FileVersion>
     <ApplicationIcon>arma_icon_white.ico</ApplicationIcon>
   </PropertyGroup>
 

--- a/ArmaReforgerServerTool/ServerConfiguration.cs
+++ b/ArmaReforgerServerTool/ServerConfiguration.cs
@@ -55,8 +55,8 @@ namespace ReforgerServerApp
             sb.AppendLine($"\"bindPort\": {BindPort},");
             sb.AppendLine($"\"publicAddress\": \"{PublicAddress}\",");
             sb.AppendLine($"\"publicPort\": {PublicPort},");
-            sb.AppendLine($"\"passwordAdmin\": \"{PasswordAdmin}\",");
             sb.AppendLine("\"game\": {");
+            sb.AppendLine($"\"passwordAdmin\": \"{PasswordAdmin}\",");
             sb.AppendLine($"\"name\": \"{ServerName}\",");
             sb.AppendLine($"\"password\": \"{Password}\",");
             sb.AppendLine($"\"scenarioId\": \"{ScenarioId}\",");


### PR DESCRIPTION
Fixes #12.
Move passwordAdmin field to `game` section of the produced server.json iaw latest parameter changes from Bohemia. This was broken in the v0.6 update.